### PR TITLE
Case-insensitive file extensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (options) {
 			return cb(new gutil.PluginError('gulp-imagemin', 'Streaming not supported'));
 		}
 
-		if (['.jpg', '.jpeg', '.png', '.gif'].indexOf(path.extname(file.path)) === -1) {
+		if (['.jpg', '.jpeg', '.png', '.gif'].indexOf(path.extname(file.path).toLowerCase()) === -1) {
 			gutil.log('gulp-imagemin: Skipping unsupported image ' + gutil.colors.blue(file.relative));
 			return cb(null, file);
 		}


### PR DESCRIPTION
Files with cased extensions (e.g. `.JPG`) are skipped, but work just fine in [image-min](https://github.com/kevva/image-min/blob/master/index.js#L80) itself. This pull allow those files to be optimized. 
