### PR TITLE
Return if raising error in optimize

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = function (options) {
 		imagemin.optimize(function (err, data) {
 			if (err) {
 				this.emit('error', new gutil.PluginError('gulp-imagemin:', err));
+				return cb();
 			}
 
 			var saved = file.contents.length - data.contents.length;


### PR DESCRIPTION
Had a situation where a lossy optimisation unavailable error was
triggering err to be filled, but then data.contents was being checked
while it was null. I think the function should exit early if there is
an error, but feel free to close if wrong (though in that case checking
data.contents is valid first would be good).
