### PR TITLE
Fix options passing to imagemin plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,9 @@ module.exports = function (options) {
 
 		var imagemin = new Imagemin()
 			.src(file.contents)
-			.use(Imagemin.gifsicle(options.interlaced))
-			.use(Imagemin.jpegtran(options.progressive))
-			.use(Imagemin.optipng(options.optimizationLevel))
+			.use(Imagemin.gifsicle({interlaced: options.interlaced}))
+			.use(Imagemin.jpegtran({progressive: options.progressive}))
+			.use(Imagemin.optipng({optimizationLevel: options.optimizationLevel}))
 			.use(Imagemin.svgo({plugins: options.svgoPlugins || []}));
 
 		if (options.use) {


### PR DESCRIPTION
The example in the 'Usage' section is broken: it specifies the "progressive: true" option but that is never applied because the plugin passes it to Imagemin.jpegtran as "true" and not as "{progressive: true}". This pull request fixes it for "progressive", "interlaced" and "optimizationLevel" options.
