### PR TITLE
Manually changing the ulimit is no longer necessary

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,9 +11,6 @@
 $ npm install --save-dev gulp-imagemin
 ```
 
-On OS X you're recommended to increase the [ulimit](http://superuser.com/a/443168/6877) as it's ridiculously low by default: `ulimit -S -n 2048`
-
-
 ## Usage
 
 ```js


### PR DESCRIPTION
EMFILE error prevented in some recent version of Gulp: https://twitter.com/contrahacks/status/482326482359177217
