### PR TITLE
Add option to quiet gulp-imagemin logging.

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,13 +73,18 @@ module.exports = function (options) {
 			cb();
 		}.bind(this));
 	}, function (cb) {
-		var percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;
-		var msg = 'Minified ' + totalFiles + ' ';
+		var percent, msg;
 
-		msg += totalFiles === 1 ? 'image' : 'images';
-		msg += chalk.gray(' (saved ' + prettyBytes(totalSavedBytes) + ' - ' + percent.toFixed(1).replace(/\.0$/, '') + '%)');
+		if (!options.quiet) {
+	 		percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;
+			msg = 'Minified ' + totalFiles + ' ';
+	
+			msg += totalFiles === 1 ? 'image' : 'images';
+			msg += chalk.gray(' (saved ' + prettyBytes(totalSavedBytes) + ' - ' + percent.toFixed(1).replace(/\.0$/, '') + '%)');
+	
+			gutil.log('gulp-imagemin:', msg);
+		}
 
-		gutil.log('gulp-imagemin:', msg);
 		cb();
 	});
 };


### PR DESCRIPTION
Add a quiet option so that users can choose to not be distracted by messages, such as: `gulp-imagemin: Minified 174 images`
