### PR TITLE
Added verbose as a passable boolean option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ var Imagemin = require('imagemin');
 
 module.exports = function (options) {
 	options = assign({}, options || {});
-	options.verbose = process.argv.indexOf('--verbose') !== -1;
+	if (typeof options.verbose !== 'boolean') {
+		options.verbose = process.argv.indexOf('--verbose') !== -1;
+	}
 
 	var totalBytes = 0;
 	var totalSavedBytes = 0;

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ Options are applied to the correct files.
 
 ##### optimizationLevel *(png)*
 
-Type: `number`  
+Type: `number`
 Default: `3`
 
 Select an optimization level between `0` and `7`.
@@ -68,31 +68,38 @@ Level and trials:
 
 ##### progressive *(jpg)*
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Lossless conversion to progressive.
 
 ##### interlaced *(gif)*
 
-Type: `boolean`  
+Type: `boolean`
 Default: `false`
 
 Interlace gif for progressive rendering.
 
 ##### svgoPlugins *(svg)*
 
-Type: `array`  
+Type: `array`
 Default: `[]`
 
 Customize which SVGO plugins to use. [More here](https://github.com/sindresorhus/grunt-svgmin#available-optionsplugins).
 
 ##### use
 
-Type: `array`  
+Type: `array`
 Default: `null`
 
 Additional [plugins](https://npmjs.org/keyword/imageminplugin) to use with imagemin.
+
+##### verbose
+
+Type: `boolean`
+Default: `false`
+
+Enable verbose output: Show individual file statistics, unsupported file warnings, etc. Alternatively you can use gulp's `--verbose` flag.
 
 
 ## License


### PR DESCRIPTION
Verbose output is already supported via gulp's --verbose flag. This simply allows you to specify `verbose: true` in the `imagemin` options instead of using `--verbose`.

The `--verbose` flag will be used if the `verbose` flag is missing or is not a boolean, thus preserving backwards compatibility.
