### PR TITLE
Add support for gulp --silent

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,10 @@ module.exports = function (opts) {
 			msg += chalk.gray(' (saved ' + prettyBytes(totalSavedBytes) + ' - ' + percent.toFixed(1).replace(/\.0$/, '') + '%)');
 		}
 
-		gutil.log('gulp-imagemin:', msg);
+		if (opts.verbose) {
+			gutil.log('gulp-imagemin:', msg);
+		}
+
 		cb();
 	});
 };

--- a/index.js
+++ b/index.js
@@ -9,9 +9,11 @@ var Imagemin = require('imagemin');
 var plur = require('plur');
 
 module.exports = function (opts) {
+	var argv = require('minimist')(process.argv.slice(2));
+
 	opts = assign({
 		// TODO: remove this when gulp get's a real logger with levels
-		verbose: process.argv.indexOf('--verbose') !== -1
+		verbose: !argv.silent || false
 	}, opts);
 
 	var totalBytes = 0;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chalk": "^1.0.0",
     "gulp-util": "^3.0.0",
     "imagemin": "^4.0.0",
+    "minimist": "^1.2.0",
     "object-assign": "^4.0.1",
     "plur": "^2.0.0",
     "pretty-bytes": "^2.0.1",


### PR DESCRIPTION
re #140, not sure what the status of gulplog is, but this is a quick hack to respect the `--silent` flag.

could do it differently depending on how you want to handle `--verbose`, also requires the minimist npm package. so definitely understand if it's overkill, just needed the functionality for my own personal use