### PR TITLE
verbose option for the «minified {n} images» message

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,6 @@ module.exports = function (opts) {
 			if (totalFiles > 0) {
 				msg += chalk.gray(' (saved ' + prettyBytes(totalSavedBytes) + ' - ' + percent.toFixed(1).replace(/\.0$/, '') + '%)');
 			}
-	
 			gutil.log('gulp-imagemin:', msg);
 		}
 		cb();

--- a/index.js
+++ b/index.js
@@ -80,12 +80,13 @@ module.exports = function (opts) {
 	}, function (cb) {
 		var percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;
 		var msg = 'Minified ' + totalFiles + ' ' + plur('image', totalFiles);
-
-		if (totalFiles > 0) {
-			msg += chalk.gray(' (saved ' + prettyBytes(totalSavedBytes) + ' - ' + percent.toFixed(1).replace(/\.0$/, '') + '%)');
+		if (opts.verbose) {
+			if (totalFiles > 0) {
+				msg += chalk.gray(' (saved ' + prettyBytes(totalSavedBytes) + ' - ' + percent.toFixed(1).replace(/\.0$/, '') + '%)');
+			}
+	
+			gutil.log('gulp-imagemin:', msg);
 		}
-
-		gutil.log('gulp-imagemin:', msg);
 		cb();
 	});
 };


### PR DESCRIPTION
[index.js#L83-L89](https://github.com/epiloque/gulp-imagemin/blob/85b9ab6d2843c2b303f9aeaf26fb7f0c8cadc3a7/index.js#L83-L89)

```javascript
		if (opts.verbose) {
			if (totalFiles > 0) {
				msg += chalk.gray(' (saved ' + prettyBytes(totalSavedBytes) + ' - ' + percent.toFixed(1).replace(/\.0$/, '') + '%)');
			}
	
			gutil.log('gulp-imagemin:', msg);
		}
```

Thank you