### PR TITLE
demonstrate svgo options need to be in their own literals

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,10 @@ gulp.task('default', () => {
 	return gulp.src('src/images/*')
 		.pipe(imagemin({
 			progressive: true,
-			svgoPlugins: [{removeViewBox: false}],
+			svgoPlugins: [
+				{removeViewBox: false},
+				{cleanupIDs: false},
+			],
 			use: [pngquant()]
 		}))
 		.pipe(gulp.dest('dist/images'));


### PR DESCRIPTION
Had me scratching my head why only the first option was being applied against my files when I had the following:

```javascript
...
  svgoPlugins: [
    {
      removeViewBox: false,
      cleanupIDs: false,
    }
  ]
...
```

when I needed the following:

```javascript
...
  svgoPlugins: [
    { removeViewBox: false },
    { cleanupIDs: false },
  ]
...
```