### PR TITLE
Make optionalDependencies really optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,23 @@
 const path = require('path');
 const gutil = require('gulp-util');
 const through = require('through2-concurrent');
+const plur = require('plur');
 const prettyBytes = require('pretty-bytes');
 const chalk = require('chalk');
 const imagemin = require('imagemin');
-const imageminGifsicle = require('imagemin-gifsicle');
-const imageminJpegtran = require('imagemin-jpegtran');
-const imageminOptipng = require('imagemin-optipng');
-const imageminSvgo = require('imagemin-svgo');
-const plur = require('plur');
+const defaultPlugins = [];
+try {
+	defaultPlugins.push(require('imagemin-gifsicle')());
+} catch (er) {}
+try {
+	defaultPlugins.push(require('imagemin-jpegtran')());
+} catch (er) {}
+try {
+	defaultPlugins.push(require('imagemin-optipng')());
+} catch (er) {}
+try {
+	defaultPlugins.push(require('imagemin-svgo')());
+} catch (er) {}
 
 module.exports = (plugins, opts) => {
 	if (typeof plugins === 'object' && !Array.isArray(plugins)) {
@@ -48,12 +57,7 @@ module.exports = (plugins, opts) => {
 			return;
 		}
 
-		const use = plugins || [
-			imageminGifsicle(),
-			imageminJpegtran(),
-			imageminOptipng(),
-			imageminSvgo()
-		];
+		const use = plugins || defaultPlugins;
 
 		imagemin.buffer(file.contents, {use})
 			.then(data => {
@@ -90,8 +94,3 @@ module.exports = (plugins, opts) => {
 		cb();
 	});
 };
-
-module.exports.gifsicle = imageminGifsicle;
-module.exports.jpegtran = imageminJpegtran;
-module.exports.optipng = imageminOptipng;
-module.exports.svgo = imageminSvgo;

--- a/index.js
+++ b/index.js
@@ -8,16 +8,24 @@ const chalk = require('chalk');
 const imagemin = require('imagemin');
 const defaultPlugins = [];
 try {
-	defaultPlugins.push(require('imagemin-gifsicle')());
+	const imageminGifsicle = require('imagemin-gifsicle');
+	defaultPlugins.push(imageminGifsicle());
+	module.exports.gifsicle = imageminGifsicle;
 } catch (er) {}
 try {
-	defaultPlugins.push(require('imagemin-jpegtran')());
+	const imageminJpegtran = require('imagemin-jpegtran');
+	defaultPlugins.push(imageminJpegtran());
+	module.exports.jpegtran = imageminJpegtran;
 } catch (er) {}
 try {
-	defaultPlugins.push(require('imagemin-optipng')());
+	const imageminOptipng = require('imagemin-optipng');
+	defaultPlugins.push(imageminOptipng());
+	module.exports.optipng = imageminOptipng;
 } catch (er) {}
 try {
-	defaultPlugins.push(require('imagemin-svgo')());
+	const imageminSvgo = require('imagemin-svgo');
+	defaultPlugins.push(imageminSvgo());
+	module.exports.svgo = imageminSvgo;
 } catch (er) {}
 
 module.exports = (plugins, opts) => {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "ava": "*",
     "get-stream": "^2.2.0",
+    "imagemin-pngquant": "^5.0.0",
     "pify": "^2.3.0",
     "xo": "*"
   },
@@ -52,7 +53,6 @@
     "imagemin-gifsicle": "^5.0.1",
     "imagemin-jpegtran": "^5.0.1",
     "imagemin-optipng": "^5.1.0",
-    "imagemin-pngquant": "^5.0.0",
     "imagemin-svgo": "^5.1.0"
   },
   "xo": {

--- a/package.json
+++ b/package.json
@@ -35,24 +35,24 @@
     "svg"
   ],
   "dependencies": {
-    "chalk": "^1.0.0",
-    "gulp-util": "^3.0.0",
-    "imagemin": "^5.0.0",
-    "plur": "^2.0.0",
-    "pretty-bytes": "^2.0.1",
-    "through2-concurrent": "^1.1.0"
+    "chalk": "^1.1.3",
+    "gulp-util": "^3.0.7",
+    "imagemin": "^5.1.2",
+    "plur": "^2.1.2",
+    "pretty-bytes": "^3.0.1",
+    "through2-concurrent": "^1.1.1"
   },
   "devDependencies": {
     "ava": "*",
-    "get-stream": "^2.1.0",
-    "imagemin-pngquant": "^5.0.0",
+    "get-stream": "^2.2.0",
     "pify": "^2.3.0",
     "xo": "*"
   },
   "optionalDependencies": {
-    "imagemin-gifsicle": "^5.0.0",
-    "imagemin-jpegtran": "^5.0.0",
+    "imagemin-gifsicle": "^5.0.1",
+    "imagemin-jpegtran": "^5.0.1",
     "imagemin-optipng": "^5.1.0",
+    "imagemin-pngquant": "^5.0.0",
     "imagemin-svgo": "^5.1.0"
   },
   "xo": {


### PR DESCRIPTION
Node4 (with its npm version) doesnt install optionalDependencies by itself. That makes v3.0.1 fail when not all 4 imagemin-libs are installed. This pull-request makes them really optional.