### PR TITLE
Prevent unhandled exception from being suppressed by Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ module.exports = (plugins, opts) => {
 				cb(null, file);
 			})
 			.catch(err => {
-				cb(new gutil.PluginError('gulp-imagemin:', err, {fileName: file.path}));
+				// TODO: remove this setImmediate when gulp 4 is targeted
+				setImmediate(cb, new gutil.PluginError('gulp-imagemin', err, {fileName: file.path}));
 			});
 	}, cb => {
 		const percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;


### PR DESCRIPTION
[Imagemin v5.x uses Promise](https://github.com/imagemin/imagemin/blob/ae1cac8d76b0556539d5391244ef3cf9cb3d1ded/index.js#L66), so we should have added the same safety net as https://github.com/sindresorhus/gulp-autoprefixer/commit/53ad3c27aded781383ad1ca54914a6583b1fd12b.

Fixes https://github.com/sindresorhus/gulp-imagemin/issues/183.
