### PR TITLE
Type of `options`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,9 @@ Default: `[imagemin.gifsicle(), imagemin.jpegtran(), imagemin.optipng(), imagemi
 
 #### options
 
+Type: `obj`<br>
+Default: `false`
+
 ##### verbose
 
 Type: `boolean`<br>


### PR DESCRIPTION
Type of `options` is missing in readme.md