### PR TITLE
Make optional imagemin dependencies required

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
     "chalk": "^1.0.0",
     "gulp-util": "^3.0.0",
     "imagemin": "^5.0.0",
+    "imagemin-gifsicle": "^5.0.0",
+    "imagemin-jpegtran": "^5.0.0",
+    "imagemin-optipng": "^5.1.0",
+    "imagemin-svgo": "^5.1.0"
     "plur": "^2.0.0",
     "pretty-bytes": "^2.0.1",
     "through2-concurrent": "^1.1.0"
@@ -48,12 +52,6 @@
     "imagemin-pngquant": "^5.0.0",
     "pify": "^2.3.0",
     "xo": "*"
-  },
-  "optionalDependencies": {
-    "imagemin-gifsicle": "^5.0.0",
-    "imagemin-jpegtran": "^5.0.0",
-    "imagemin-optipng": "^5.1.0",
-    "imagemin-svgo": "^5.1.0"
   },
   "xo": {
     "esnext": true

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "imagemin-gifsicle": "^5.0.0",
     "imagemin-jpegtran": "^5.0.0",
     "imagemin-optipng": "^5.1.0",
-    "imagemin-svgo": "^5.1.0"
+    "imagemin-svgo": "^5.1.0",
     "plur": "^2.0.0",
     "pretty-bytes": "^2.0.1",
     "through2-concurrent": "^1.1.0"


### PR DESCRIPTION
These are required at `index.js` and thus should not be optional.

Fixes #221