### PR TITLE
Improve documentation on custom options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,8 @@ $ npm install --save-dev gulp-imagemin
 
 ## Usage
 
+### Basic
+
 ```js
 const gulp = require('gulp');
 const imagemin = require('gulp-imagemin');
@@ -31,6 +33,36 @@ gulp.task('default', () =>
 );
 ```
 
+### Custom Options
+
+```js
+const gulp = require('gulp');
+const imagemin = require('gulp-imagemin');
+
+gulp.task('default', () => {
+    return gulp.src('src/images/*')
+	.pipe(imagemin([
+		imagemin.gifsicle({interlaced: true}),
+		imagemin.jpegtran({progressive: true}),
+		imagemin.optipng({optimizationLevel: 5}),
+		imagemin.svgo({plugins: [{removeViewBox: true}]})
+	]))
+	.pipe(gulp.dest('dist/images'));
+});
+```
+
+Note that you may come across an older, implicit syntax. In versions < 3, the same was written like this:
+
+```js
+...
+	.pipe(imagemin({
+	    interlaced: true,
+	    progressive: true,
+	    optimizationLevel: 5,
+	    svgoPlugins: [{removeViewBox: true}]
+	}))
+...	
+```
 
 ## API
 
@@ -58,13 +90,17 @@ Default: `[imagemin.gifsicle(), imagemin.jpegtran(), imagemin.optipng(), imagemi
 
 Type: `Object`
 
-##### verbose
-
+The only supported `imagemin` option is **verbose**
+	
 Type: `boolean`<br>
 Default: `false`
 
-Output more detailed information.
+Turning `verbose` on will log info on every file passed to `imagemin`:
 
+```bash
+gulp-imagemin: ✔ image1.png (already optimized)
+gulp-imagemin: ✔ image2.png (saved 91 B - 0.4%)
+```
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ gulp.task('default', () =>
 );
 ```
 
-### Custom Plugin Options
+### Custom plugin options
 
 ```js
 ...
@@ -59,12 +59,15 @@ Note that you may come across an older, implicit syntax. In versions < 3, the sa
 ...	
 ```
 
-### Custom Plugin Options and Custom `gulp-imagemin` options
+### Custom plugin options and custom `gulp-imagemin` options
+
 ```js
 ...
 	.pipe(imagemin([
 		imagemin.svgo({plugins: [{removeViewBox: true}]})
-	],{verbose: true}))
+	], {
+		verbose: true
+	}))
 ...
 ```
 
@@ -95,17 +98,18 @@ Default: `[imagemin.gifsicle(), imagemin.jpegtran(), imagemin.optipng(), imagemi
 
 Type: `Object`
 
-The only supported `imagemin` option is **verbose**
+##### verbose
 	
 Type: `boolean`<br>
 Default: `false`
 
-Turning `verbose` on will log info on every file passed to `imagemin`:
+Enabling this will log info on every image passed to `gulp-imagemin`:
 
-```bash
+```
 gulp-imagemin: ✔ image1.png (already optimized)
 gulp-imagemin: ✔ image2.png (saved 91 B - 0.4%)
 ```
+
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -33,22 +33,17 @@ gulp.task('default', () =>
 );
 ```
 
-### Custom Options
+### Custom Plugin Options
 
 ```js
-const gulp = require('gulp');
-const imagemin = require('gulp-imagemin');
-
-gulp.task('default', () => {
-    return gulp.src('src/images/*')
+...
 	.pipe(imagemin([
 		imagemin.gifsicle({interlaced: true}),
 		imagemin.jpegtran({progressive: true}),
 		imagemin.optipng({optimizationLevel: 5}),
 		imagemin.svgo({plugins: [{removeViewBox: true}]})
 	]))
-	.pipe(gulp.dest('dist/images'));
-});
+...
 ```
 
 Note that you may come across an older, implicit syntax. In versions < 3, the same was written like this:
@@ -63,6 +58,16 @@ Note that you may come across an older, implicit syntax. In versions < 3, the sa
 	}))
 ...	
 ```
+
+### Custom Plugin Options and Custom `gulp-imagemin` options
+```js
+...
+	.pipe(imagemin([
+		imagemin.svgo({plugins: [{removeViewBox: true}]})
+	],{verbose: true}))
+...
+```
+
 
 ## API
 


### PR DESCRIPTION
For #248 

The documentation doesn't currently make passing plugin options clear. This adds a custom plugins options example, including a mention of the old syntax (there are many instances of the old syntax out in the wild in projects, on SO, etc). The example is based on the v3.0.0 release notes, but uses a non-default svgo option.

Also adds an example of how to pass `verbose: true`.

Also adds an example of what you'll see with `verbose: true`.