### PR TITLE
Only show actually compressed images in success message

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,9 +84,11 @@ module.exports = (plugins, opts) => {
 				const savedMsg = `saved ${prettyBytes(saved)} - ${percent.toFixed(1).replace(/\.0$/, '')}%`;
 				const msg = saved > 0 ? savedMsg : 'already optimized';
 
-				totalBytes += originalSize;
-				totalSavedBytes += saved;
-				totalFiles++;
+				if (saved > 0) {
+					totalBytes += originalSize;
+					totalSavedBytes += saved;
+					totalFiles++;
+				}
 
 				if (opts.verbose) {
 					gutil.log('gulp-imagemin:', chalk.green('✔ ') + file.relative + chalk.gray(` (${msg})`));


### PR DESCRIPTION
Opted to just silently ignore files that's already minified. We could add them to the success message but I couldn't figure out a nice way to format it. Not sure if it's that useful either.

What this solves is the "false positives" that happens when users are trying to optimize images without plugins that supports them. E.g. when piping SVG images but without the `imagemin-svgo` plugin. Prior to this PR, we would report these images as minified in the success message.

Fixes #251.