### PR TITLE
Return the gulp stream

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ const gulp = require('gulp');
 const imagemin = require('gulp-imagemin');
 
 gulp.task('default', () =>
-	gulp.src('src/images/*')
+	return gulp.src('src/images/*')
 		.pipe(imagemin())
 		.pipe(gulp.dest('dist/images'))
 );


### PR DESCRIPTION
Returning the Gulp stream is important for gulp know that your task is finished, especially when there are other tasks depending on your task. This should be done by either returning the stream, or using the callback argument.

By changing the readme to show best practices, we can ensure everyone will follow the correct pattern