### PR TITLE
Removed use of deprecated gutil

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const path = require('path');
-const gutil = require('gulp-util');
+const log = require('fancy-log');
+const PluginError = require('plugin-error');
 const through = require('through2-concurrent');
 const prettyBytes = require('pretty-bytes');
 const chalk = require('chalk');
@@ -14,7 +15,7 @@ const loadPlugin = (plugin, args) => {
 	try {
 		return require(`imagemin-${plugin}`).apply(null, args);
 	} catch (err) {
-		gutil.log(`${PLUGIN_NAME}: Couldn't load default plugin "${plugin}"`);
+		log(`${PLUGIN_NAME}: Couldn't load default plugin "${plugin}"`);
 	}
 };
 
@@ -61,13 +62,13 @@ module.exports = (plugins, opts) => {
 		}
 
 		if (file.isStream()) {
-			cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
+			cb(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
 			return;
 		}
 
 		if (validExts.indexOf(path.extname(file.path).toLowerCase()) === -1) {
 			if (opts.verbose) {
-				gutil.log(`${PLUGIN_NAME}: Skipping unsupported image ${chalk.blue(file.relative)}`);
+				log(`${PLUGIN_NAME}: Skipping unsupported image ${chalk.blue(file.relative)}`);
 			}
 
 			cb(null, file);
@@ -92,7 +93,7 @@ module.exports = (plugins, opts) => {
 				}
 
 				if (opts.verbose) {
-					gutil.log(PLUGIN_NAME + ':', chalk.green('✔ ') + file.relative + chalk.gray(` (${msg})`));
+					log(PLUGIN_NAME + ':', chalk.green('✔ ') + file.relative + chalk.gray(` (${msg})`));
 				}
 
 				file.contents = data;
@@ -100,7 +101,7 @@ module.exports = (plugins, opts) => {
 			})
 			.catch(err => {
 				// TODO: remove this setImmediate when gulp 4 is targeted
-				setImmediate(cb, new gutil.PluginError(PLUGIN_NAME, err, {fileName: file.path}));
+				setImmediate(cb, new PluginError(PLUGIN_NAME, err, {fileName: file.path}));
 			});
 	}, cb => {
 		const percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;
@@ -110,7 +111,7 @@ module.exports = (plugins, opts) => {
 			msg += chalk.gray(` (saved ${prettyBytes(totalSavedBytes)} - ${percent.toFixed(1).replace(/\.0$/, '')}%)`);
 		}
 
-		gutil.log(PLUGIN_NAME + ':', msg);
+		log(PLUGIN_NAME + ':', msg);
 		cb();
 	});
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 	],
 	"dependencies": {
 		"chalk": "^2.1.0",
-		"gulp-util": "^3.0.8",
+		"fancy-log": "^1.3.2",
+		"plugin-error": "^0.1.2",
 		"imagemin": "^5.3.1",
 		"plur": "^2.1.2",
 		"pretty-bytes": "^4.0.2",
@@ -47,7 +48,8 @@
 		"get-stream": "^3.0.0",
 		"imagemin-pngquant": "^5.0.1",
 		"pify": "^3.0.0",
-		"xo": "*"
+		"xo": "*",
+		"vinyl": "^2.1.0"
 	},
 	"optionalDependencies": {
 		"imagemin-gifsicle": "^5.2.0",

--- a/test.js
+++ b/test.js
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
-import gutil from 'gulp-util';
 import imageminPngquant from 'imagemin-pngquant';
 import pify from 'pify';
+import Vinyl from 'vinyl';
 import getStream from 'get-stream';
 import test from 'ava';
 import m from '.';
@@ -13,7 +13,7 @@ const createFixture = async plugins => {
 	const buf = await fsP.readFile('fixture.png');
 	const stream = m(plugins);
 
-	stream.end(new gutil.File({
+	stream.end(new Vinyl({
 		path: path.join(__dirname, 'fixture.png'),
 		contents: buf
 	}));
@@ -39,7 +39,7 @@ test('use custom plugins', async t => {
 
 test('skip unsupported images', async t => {
 	const stream = m();
-	stream.end(new gutil.File({path: path.join(__dirname, 'fixture.bmp')}));
+	stream.end(new Vinyl({path: path.join(__dirname, 'fixture.bmp')}));
 	const file = await getStream.array(stream);
 
 	t.is(file[0].contents, null);


### PR DESCRIPTION
Created this little pull request to replace deprecated gulp-util with proper dependencies.

Thanks for this great tool! 

For more info about the deprecation see: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

Fixes #290 