### PR TITLE
Prevent any log if verbose is set to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,8 +110,9 @@ module.exports = (plugins, opts) => {
 		if (totalFiles > 0) {
 			msg += chalk.gray(` (saved ${prettyBytes(totalSavedBytes)} - ${percent.toFixed(1).replace(/\.0$/, '')}%)`);
 		}
-
-		log(PLUGIN_NAME + ':', msg);
+		if (opts.verbose) {
+			log(PLUGIN_NAME + ':', msg);
+		}
 		cb();
 	});
 };


### PR DESCRIPTION
Very simple fix to prevent any log if verbose is set to false.
Or, maybe, do you prefer to have another option like silent to mute all logs and keep that one active by default?

Thanks :)