### PR TITLE
Add `silent` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = (plugins, options) => {
 
 	options = {
 		// TODO: Remove this when Gulp gets a real logger with levels
+		silent: process.argv.includes('--silent'),
 		verbose: process.argv.includes('--verbose'),
 		...options
 	};
@@ -102,14 +103,17 @@ module.exports = (plugins, options) => {
 			}
 		})();
 	}, callback => {
-		const percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;
-		let msg = `Minified ${totalFiles} ${plur('image', totalFiles)}`;
+		if (!options.silent) {
+			const percent = totalBytes > 0 ? (totalSavedBytes / totalBytes) * 100 : 0;
+			let msg = `Minified ${totalFiles} ${plur('image', totalFiles)}`;
 
-		if (totalFiles > 0) {
-			msg += chalk.gray(` (saved ${prettyBytes(totalSavedBytes)} - ${percent.toFixed(1).replace(/\.0$/, '')}%)`);
+			if (totalFiles > 0) {
+				msg += chalk.gray(` (saved ${prettyBytes(totalSavedBytes)} - ${percent.toFixed(1).replace(/\.0$/, '')}%)`);
+			}
+
+			log(`${PLUGIN_NAME}:`, msg);
 		}
 
-		log(`${PLUGIN_NAME}:`, msg);
 		callback();
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -124,4 +124,6 @@ gulp-imagemin: ✔ image2.png (saved 91 B - 0.4%)
 Type: `boolean`<br>
 Default: `false`
 
-By default, `gulp-imagemin` logs the number of images that have been minified. By enabling the `--silent` option this information won't be logged anymore.
+Don't log the number of images that have been minified.
+
+You can also enable this from the command-line with the `--silent` flag.

--- a/readme.md
+++ b/readme.md
@@ -126,4 +126,4 @@ Default: `false`
 
 Don't log the number of images that have been minified.
 
-You can also enable this from the command-line with the `--silent` flag.
+You can also enable this from the command-line with the `--silent` flag if the option is not already specified.

--- a/readme.md
+++ b/readme.md
@@ -118,3 +118,10 @@ Enabling this will log info on every image passed to `gulp-imagemin`:
 gulp-imagemin: ✔ image1.png (already optimized)
 gulp-imagemin: ✔ image2.png (saved 91 B - 0.4%)
 ```
+
+##### silent
+
+Type: `boolean`<br>
+Default: `false`
+
+By default, `gulp-imagemin` logs the number of images that have been minified. By enabling the `--silent` option this information won't be logged anymore.


### PR DESCRIPTION
By default, `gulp-imagemin` logs the number of images that have been minified. This PR adds a `--silent` to disable this logging.

Fixes #332